### PR TITLE
nix/hm-module: init

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,11 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs";
 
-  outputs = {nixpkgs, ...}: let
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  }: let
     systems = ["x86_64-linux" "aarch64-linux"];
     forEachSystem = nixpkgs.lib.genAttrs systems;
 
@@ -14,5 +18,9 @@
     packages = forEachSystem (system: {
       default = pkgsForEach.${system}.callPackage ./nix/package.nix {};
     });
+
+    homeManagerModules = {
+      default = import ./nix/hm-module.nix self;
+    };
   };
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,44 @@
+self: {
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  cfg = config.services.tailray;
+
+  inherit (lib.meta) getExe;
+  inherit (lib.options) mkEnableOption mkPackageOption;
+in {
+  meta.maintainers = with lib.maintainers; [fufexan];
+
+  options.services.tailray = {
+    enable = mkEnableOption "Tailray, a Tailscale tray";
+
+    package =
+      mkPackageOption pkgs "tailray" {}
+      // {
+        default = self.packages.${pkgs.system}.default;
+      };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [cfg.package];
+
+    systemd.user.services.tailray = {
+      Install.WantedBy = ["graphical-session.target"];
+
+      Unit = {
+        Description = "Tailscale tray item";
+        Requires = "tray.target";
+        After = ["graphical-session-pre.target" "tray.target"];
+        PartOf = ["graphical-session.target"];
+      };
+
+      Service = {
+        ExecStart = "${getExe cfg.package}";
+        Restart = "always";
+        RestartSec = "10";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Automatically start the service along with `graphical-session.target`.
