### PR TITLE
nix: fix warnings

### DIFF
--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -17,7 +17,7 @@ in {
     package =
       mkPackageOption pkgs "tailray" {}
       // {
-        default = self.packages.${pkgs.system}.tailray;
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.tailray;
       };
   };
 

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -17,7 +17,7 @@ in {
     package =
       mkPackageOption pkgs "tailray" {}
       // {
-        default = self.packages.${pkgs.system}.tailray;
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.tailray;
       };
   };
 


### PR DESCRIPTION
Fix to comply with the renaming of pkgs.system.