### PR TITLE
nix: fix xorg warning

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,7 +3,7 @@
   dbus,
   pkg-config,
   rustPlatform,
-  xorg,
+  libxcb,
   rev ? "dirty",
 }: let
   cargoToml = lib.importTOML ../Cargo.toml;
@@ -25,7 +25,7 @@ in
 
     strictDeps = true;
     nativeBuildInputs = [pkg-config];
-    buildInputs = [dbus xorg.libxcb];
+    buildInputs = [dbus libxcb];
 
     meta = {
       description = "Rust implementation of tailscale-systray";

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -9,13 +9,13 @@
   cargo,
   rustc,
   rustPlatform,
-  xorg,
+  libxcb,
 }:
 mkShell {
   env."RUST_SRC_PATH" = "${rustPlatform.rustLibSrc}";
 
   strictDeps = true;
-  buildInputs = [dbus xorg.libxcb];
+  buildInputs = [dbus libxcb];
   nativeBuildInputs = [
     pkg-config
     python3


### PR DESCRIPTION
Simple rename to fix warning for the deprecated xorg package set.